### PR TITLE
Package updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM flywheelsports/servicebase:0.0.2
+FROM node:7.8.0-alpine
 MAINTAINER Carlos Justiniano cjus34@gmail.com
 EXPOSE 80
 RUN mkdir -p /usr/src/app

--- a/hydra-router.js
+++ b/hydra-router.js
@@ -30,7 +30,7 @@ config.init('./config/config.json')
     const hydra = require('hydra');
     const version = require('./package.json').version;
     const serviceRouter = require('./servicerouter');
-    const WebSocketServer = require('uws').Server;
+    const WebSocketServer = require('ws').Server;
     config.version = version;
     config.hydra.serviceVersion = version;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra-router",
-  "version": "1.0.16",
+  "version": "1.0.18",
   "description": "A service which routes requests to hydra-based microservices",
   "author": {
     "name": "Carlos Justiniano",
@@ -17,24 +17,24 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@risingstack/trace": "3.5.3",
+    "@risingstack/trace": "3.6.2",
     "bluebird": "3.5.0",
     "fwsp-config": "1.1.5",
-    "hydra": "1.0.6",
     "fwsp-jsutils": "1.0.10",
-    "fwsp-logger": "0.1.3",
+    "fwsp-logger": "0.1.4",
     "fwsp-server-response": "2.2.5",
     "fwsp-umf-message": "0.4.3",
+    "hydra": "1.0.8",
     "request": "2.81.0",
     "route-parser": "0.0.5",
-    "uws": "0.14.1"
+    "ws": "2.2.3"
   },
   "devDependencies": {
     "chai": "3.5.0",
-    "eslint": "3.18.0",
+    "eslint": "3.19.0",
     "eslint-config-google": "0.7.1",
     "eslint-plugin-mocha": "4.9.0",
     "mocha": "3.2.0",
-    "superagent": "3.5.0"
+    "superagent": "3.5.2"
   }
 }


### PR DESCRIPTION
* switch to node 7.8.0 and alphine docker image.
* reverted back to the ws websocket package instead of using uvw. The reason is to allow for the use of the lighter alphine package and improved portability.
* updated to hydra core 1.0.8 and fwsp-logger 0.1.4.
* updated other dev dependencies.