### PR TITLE
Queuer DB Config

### DIFF
--- a/servicerouter.js
+++ b/servicerouter.js
@@ -70,7 +70,8 @@ class ServiceRouter {
     hydra.on('message', this._handleIncomingChannelMessage);
 
     this.queuer = new Queuer();
-    this.queuer.init(hydra.getClonedRedisClient(), 3);
+    let queuerDB = config.hydra.queuerDB ? config.hydra.queuerDB : 0;
+    this.queuer.init(hydra.getClonedRedisClient(), queuerDB);
 
     this.routerTable = routesObj;
     this._refreshRoutes();


### PR DESCRIPTION
Adding new config option `queuerDB` for setting which redis db to use for queuing. If `queuerDB` is not present, default to DB 0.