### PR TITLE
Update to hydra 1.4.18 and support for token-less health checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra-router",
-  "version": "1.4.18",
+  "version": "1.4.19",
   "lockfileVersion": 1,
   "dependencies": {
     "acorn": {
@@ -1256,9 +1256,9 @@
       "dev": true
     },
     "hydra": {
-      "version": "1.4.16",
-      "resolved": "https://registry.npmjs.org/hydra/-/hydra-1.4.16.tgz",
-      "integrity": "sha512-jVVER9oq31tLl77niIOzJ1p+ygQ99iGTJCLGA23DGJCS1eUfuQ6I5tEbTVSMhGcsOTyf3Ap25NEduCm3T/CYaQ=="
+      "version": "1.4.18",
+      "resolved": "https://registry.npmjs.org/hydra/-/hydra-1.4.18.tgz",
+      "integrity": "sha512-35C8mh6+VO3tST87eoxvOsmFZYrdAdDyoYwOIITDnoI55y+UQFtgTkko0yko41jL/kA9l6DPU6gucVDD/h+1jw=="
     },
     "hydra-express-plugin": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra-router",
-  "version": "1.4.18",
+  "version": "1.4.19",
   "description": "A service which routes requests to hydra-based microservices",
   "author": {
     "name": "Carlos Justiniano",
@@ -20,7 +20,7 @@
     "bluebird": "3.5.0",
     "debug": "2.6.8",
     "fwsp-logger": "0.3.0",
-    "hydra": "1.4.16",
+    "hydra": "1.4.18",
     "newrelic": "1.40.0",
     "route-parser": "0.0.5",
     "ws": "3.1.0"

--- a/servicerouter.js
+++ b/servicerouter.js
@@ -595,7 +595,7 @@ class ServiceRouter {
       }
     }
 
-    if (!allowRouterCall) {
+    if (urlData.host !== 'localhost' && !allowRouterCall) {
       serverResponse.sendResponse(ServerResponse.HTTP_NOT_FOUND, response);
       return;
     }
@@ -1010,12 +1010,6 @@ class ServiceRouter {
               newRouteItems.push({
                 pattern: routePattern,
                 route: new Route(routePattern)
-              });
-            });
-            [`/${serviceName}`, `/${serviceName}/`, `/${serviceName}/:rest`].forEach((pattern) => {
-              newRouteItems.push({
-                pattern: pattern,
-                route: new Route(pattern)
               });
             });
             this.routerTable[serviceName] = newRouteItems;


### PR DESCRIPTION
in docker container. Also removed automatic adding of web routes which is now handled in hydra-core.