### PR TITLE
Convert form-url encoded content-type to json & use qs parser

### DIFF
--- a/lib/servicerouter.js
+++ b/lib/servicerouter.js
@@ -779,7 +779,21 @@ class ServiceRouter {
       headers: Object.assign({}, request.headers)
     };
 
-    message.body = Utils.safeJSONParse(body) || {};
+    if (request.headers['content-type'] === 'application/x-www-form-urlencoded') {
+      // for some reason, not changing the content-type despite having a
+      // properly parsed body (see below) results in a stringified body rather than
+      // a body. This may be because the actually body that is sent over the
+      // wire may be due to a method that is used to convert the body right
+      // in the hydra library before the message is transmitted to the service
+      message.headers['content-type'] = 'application/json';
+      try {
+        message.body = querystring.parse(body.toString());
+      } catch (e) {
+        message.body = {};
+      }
+    } else {
+      message.body = Utils.safeJSONParse(body) || {};
+    }
 
     if (request.headers['authorization']) {
       message.authorization = request.headers['authorization'];

--- a/lib/servicerouter.js
+++ b/lib/servicerouter.js
@@ -780,11 +780,6 @@ class ServiceRouter {
     };
 
     if (request.headers['content-type'] === 'application/x-www-form-urlencoded') {
-      // for some reason, not changing the content-type despite having a
-      // properly parsed body (see below) results in a stringified body rather than
-      // a body. This may be because the actually body that is sent over the
-      // wire may be due to a method that is used to convert the body right
-      // in the hydra library before the message is transmitted to the service
       message.headers['content-type'] = 'application/json';
       try {
         message.body = querystring.parse(body.toString());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra-router",
-  "version": "1.6.20",
+  "version": "1.7.0",
   "description": "A service which routes requests to hydra-based microservices",
   "author": {
     "name": "Carlos Justiniano",


### PR DESCRIPTION
- `Utils.safeJSONParse` uses `JSON.parse` under the hood which
cannot convert form url encoded query strings (which is what the
string format of the binary data/Buffer string would be) to a
"JSON Object" so we'll use the core node.js module, `querystring`
to parse it. However, this parser might not automagically convert
the Buffer to a string, so we'll convert it first and then parse
it using the correct parser.
- For some reason, we need to have the `content-type` to use
`application/json`. This is no matter if the body is correctly
parsed or not. My guess is there is some method in `hydra` library
that requires the header content type to be json rather or the
body is parsed in a string format rather than a JSON format.

This change seems to be the cleanest with minimal changes to the surface
area without also updating any other libraries (like `hydra` or `UMF`). Previously, we are
unable to send any requests with form url encoded body params whereas
now form url encoded body params will be converted to json body
params.



Pre-change logs
![image](https://user-images.githubusercontent.com/17064503/74120254-a2631e00-4b90-11ea-810c-e645192773f8.png)

Post-change logs
![image](https://user-images.githubusercontent.com/17064503/74120294-c9b9eb00-4b90-11ea-86a4-b3eb864597ea.png)
